### PR TITLE
Response error handling

### DIFF
--- a/R/traffic.R
+++ b/R/traffic.R
@@ -122,7 +122,7 @@ traffic <- function(aoi, product = "flow", from_dt = NULL, to_dt = NULL,
 
 .extract_traffic_flow <- function(data) {
   geoms <- list()
-  flow <- data.table::rbindlist(lapply(data, function(con) {
+  flow <- suppressWarnings(data.table::rbindlist(lapply(data, function(con) {
     df <- jsonlite::fromJSON(con)
     if (is.null(df$RWS$RW)) {return(NULL)}
     data.table::rbindlist(lapply(df$RWS$RW, function(rw) {
@@ -148,7 +148,7 @@ traffic <- function(aoi, product = "flow", from_dt = NULL, to_dt = NULL,
           }), fill = TRUE)
         }), fill = TRUE)
       }), fill = TRUE)
-    }), fill = TRUE)
+    }), fill = TRUE))
   flow$geometry <- geoms
   if (nrow(flow) > 0) {
     return(

--- a/R/utils.R
+++ b/R/utils.R
@@ -57,19 +57,7 @@
       if (is.character(res))
         stop("Connection error: Please check connection to the internet and proxy configuration.")
       if (res$status != 200) {
-        if (as.numeric(substr(as.character(res$status), 1, 1)) == 4) {
-          errorChar <- rawToChar(res$content)
-          Encoding(errorChar) <- encoding
-          error <- jsonlite::fromJSON(errorChar)
-          errorMessage <- sprintf(
-            "Request failed with HTTP status code %s: %s: %s: %s",
-            res$status, error$type, error$subtype, error$details)
-        } else {
-          errorMessage <- sprintf(
-            "Request failed with HTTP status code %s.",
-            res$status)
-        }
-        message(errorMessage)
+        message(sprintf("Request failed: HTTP status code %s.", res$status))
         ids <<- ids[ids != id]
       } else {
         results[[id]] <<- res


### PR DESCRIPTION
- Handle failed requests in `.get_content` properly
- Suppress warning in `traffic(..., product="flow")`, which occurs in `.extract_traffic_flow`: *In setDT(ans) : Some columns are a multi-column type (such as a matrix column): [1]. setDT will retain these columns as-is but subsequent operations like grouping and joining may fail. Please consider as.data.table() instead which will create a new column for each embedded column.*