### PR TITLE
add sf option to geocode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * Changed CI from Travis to GitHub actions.
 * Added automated pkgdown page build after pull requests and commits on master.
 * Extended test coverage on defunct function calls.
+* Added `sf` argument to `geocode()` function. If `TRUE`, the default, an {sf}
+object is returned, if `FALSE` a data.frame with `lng` and `lat` columns.
+(@dpprdan, [#44](https://github.com/munterfinger/hereR/pull/44))
 
 # version 0.3.3
 

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -8,9 +8,14 @@
 #' @param addresses character, addresses to geocode.
 #' @param autocomplete boolean, use the 'Geocoder Autocomplete' API to autocomplete addresses? Note: This options doubles the amount of requests (\code{default = FALSE}).
 #' @param url_only boolean, only return the generated URLs (\code{default = FALSE})?
+#' @param sf boolean, return an \code{sf} object (\code{default = TRUE}) or a
+#'   \code{data.frame}?
 #'
 #' @return
-#' An \code{sf} object, containing the coordinates of the geocoded addresses.
+#' If \code{sf = TRUE}, an \code{sf} object, containing the coordinates of the
+#' geocoded addresses as a geometry list column. If \code{sf = FALSE}, a
+#' \code{data.frame} containing the coordinates of the geocoded addresses as
+#' \code{lng}, \code{lat} columns.
 #' @export
 #'
 #' @examples
@@ -18,12 +23,13 @@
 #' set_key("<YOUR API KEY>")
 #'
 #' locs <- geocode(addresses = poi$city, url_only = TRUE)
-geocode <- function(addresses, autocomplete = FALSE, url_only = FALSE) {
+geocode <- function(addresses, autocomplete = FALSE, url_only = FALSE, sf = TRUE) {
 
   # Input checks
   .check_addresses(addresses)
   .check_boolean(autocomplete)
   .check_boolean(url_only)
+  .check_boolean(sf)
 
   # Add API key
   url <- .add_key(
@@ -97,14 +103,19 @@ geocode <- function(addresses, autocomplete = FALSE, url_only = FALSE) {
   # Create sf object
   if (nrow(geocoded) > 0) {
     rownames(geocoded) <- NULL
-    return(
-      sf::st_set_crs(
-        sf::st_as_sf(
-          as.data.frame(geocoded),
-          coords = c("lng", "lat")
-        ), 4326
+    # Return urls if chosen
+    if (sf) {
+      return(
+        sf::st_set_crs(
+          sf::st_as_sf(
+            as.data.frame(geocoded),
+            coords = c("lng", "lat")
+          ), 4326
+        )
       )
-    )
+    } else {
+      return(as.data.frame(geocoded))
+    }
   } else {
     return(NULL)
   }

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -6,10 +6,13 @@
 #' \href{https://developer.here.com/documentation/geocoder/topics/resource-geocode.html}{HERE Geocoder API: Geocode}
 #'
 #' @param addresses character, addresses to geocode.
-#' @param autocomplete boolean, use the 'Geocoder Autocomplete' API to autocomplete addresses? Note: This options doubles the amount of requests (\code{default = FALSE}).
-#' @param url_only boolean, only return the generated URLs (\code{default = FALSE})?
+#' @param autocomplete boolean, use the 'Geocoder Autocomplete' API to
+#'   autocomplete addresses? Note: This options doubles the amount of requests
+#'   (\code{default = FALSE}).
 #' @param sf boolean, return an \code{sf} object (\code{default = TRUE}) or a
 #'   \code{data.frame}?
+#' @param url_only boolean, only return the generated URLs (\code{default =
+#'   FALSE})?
 #'
 #' @return
 #' If \code{sf = TRUE}, an \code{sf} object, containing the coordinates of the
@@ -23,13 +26,13 @@
 #' set_key("<YOUR API KEY>")
 #'
 #' locs <- geocode(addresses = poi$city, url_only = TRUE)
-geocode <- function(addresses, autocomplete = FALSE, url_only = FALSE, sf = TRUE) {
+geocode <- function(addresses, autocomplete = FALSE, sf = TRUE, url_only = FALSE) {
 
   # Input checks
   .check_addresses(addresses)
   .check_boolean(autocomplete)
-  .check_boolean(url_only)
   .check_boolean(sf)
+  .check_boolean(url_only)
 
   # Add API key
   url <- .add_key(

--- a/man/geocode.Rd
+++ b/man/geocode.Rd
@@ -4,7 +4,7 @@
 \alias{geocode}
 \title{HERE Geocoder API: Geocode}
 \usage{
-geocode(addresses, autocomplete = FALSE, url_only = FALSE)
+geocode(addresses, autocomplete = FALSE, url_only = FALSE, sf = TRUE)
 }
 \arguments{
 \item{addresses}{character, addresses to geocode.}
@@ -12,9 +12,15 @@ geocode(addresses, autocomplete = FALSE, url_only = FALSE)
 \item{autocomplete}{boolean, use the 'Geocoder Autocomplete' API to autocomplete addresses? Note: This options doubles the amount of requests (\code{default = FALSE}).}
 
 \item{url_only}{boolean, only return the generated URLs (\code{default = FALSE})?}
+
+\item{sf}{boolean, return an \code{sf} object (\code{default = TRUE}) or a
+\code{data.frame}?}
 }
 \value{
-An \code{sf} object, containing the coordinates of the geocoded addresses.
+If \code{sf = TRUE}, an \code{sf} object, containing the coordinates of the
+geocoded addresses as a geometry list column. If \code{sf = FALSE}, a
+\code{data.frame} containing the coordinates of the geocoded addresses as
+\code{lng}, \code{lat} columns.
 }
 \description{
 Geocodes addresses using the HERE 'Geocoder' API.

--- a/man/geocode.Rd
+++ b/man/geocode.Rd
@@ -4,17 +4,20 @@
 \alias{geocode}
 \title{HERE Geocoder API: Geocode}
 \usage{
-geocode(addresses, autocomplete = FALSE, url_only = FALSE, sf = TRUE)
+geocode(addresses, autocomplete = FALSE, sf = TRUE, url_only = FALSE)
 }
 \arguments{
 \item{addresses}{character, addresses to geocode.}
 
-\item{autocomplete}{boolean, use the 'Geocoder Autocomplete' API to autocomplete addresses? Note: This options doubles the amount of requests (\code{default = FALSE}).}
-
-\item{url_only}{boolean, only return the generated URLs (\code{default = FALSE})?}
+\item{autocomplete}{boolean, use the 'Geocoder Autocomplete' API to
+autocomplete addresses? Note: This options doubles the amount of requests
+(\code{default = FALSE}).}
 
 \item{sf}{boolean, return an \code{sf} object (\code{default = TRUE}) or a
 \code{data.frame}?}
+
+\item{url_only}{boolean, only return the generated URLs (\code{default =
+FALSE})?}
 }
 \value{
 If \code{sf = TRUE}, an \code{sf} object, containing the coordinates of the

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -17,7 +17,18 @@ test_that("geocode works", {
     geocoded <- geocode(addresses = poi$city),
 
     # Tests
-    expect_equal(any(sf::st_geometry_type(geocoded) != "POINT"), FALSE),
+    expect_s3_class(geocoded, c("sf", "data.frame"), exact = TRUE),
+    expect_true(all(sf::st_geometry_type(geocoded) == "POINT")),
     expect_equal(nrow(geocoded), length(poi$city))
+  )
+  with_mock(
+    "hereR:::.get_content" = function(url) {hereR:::mock$geocode_response},
+    geocoded <- geocode(addresses = poi$city, sf = FALSE),
+
+    # Tests
+    expect_s3_class(geocoded, "data.frame", exact = TRUE),
+    expect_equal(nrow(geocoded), length(poi$city)),
+    expect_type(geocoded[["lat"]], "double"),
+    expect_type(geocoded[["lng"]], "double")
   )
 })


### PR DESCRIPTION
This PR adds an boolean `sf` argument to the `geocode()` function. If `TRUE`, the default, an {sf} object is returned as before, if `FALSE` a data.frame with `lng` and `lat` columns. 

Motivation: I often need the coordinates from geocoding as lat/lon columns instead of an sfc. Right now, one would have to convert the sfc back with `st_coordinates` and - at least for me - it would be helpful to get the lat/lon columns directly (and skip the sf roundtrip).

Let me know whether you feel this is within the scope of the package. If it is, I can also add a test and NEWS item.

Alternatively, one could add a `remove` option, as in `sf::st_as_sf(remove = FALSE)` to prohibit removing the lat/lng columns from the {sf} object. In my own workflow I would still have to delete the sfc column, though, and I cannot think of a sensible workflow where one would need both lat/lng and sfc columns simultaneously at the moment. That's why I chose the approach above. 