### PR TITLE
Clarify connection documentation

### DIFF
--- a/R/connection.R
+++ b/R/connection.R
@@ -15,7 +15,7 @@
 #' @param datetime \code{POSIXct} object, datetime for the departure (or arrival if \code{arrival = TRUE}).
 #' @param arrival boolean, calculate connections for arrival at the defined time (\code{default = FALSE})?
 #' @param results numeric, maximum number of suggested public transport routes (Valid range: 1 and 6).
-#' @param transfers numeric, maximum number of transfers allowed per route (Valid range: -1 and 6, \code{default = -1}).
+#' @param transfers numeric, maximum number of transfers allowed per route (Valid range: -1 and 6, whereby the \code{default = -1} allows for unlimited transfers).
 #' @param summary boolean, return a summary of the public transport connections instead of the sections of the routes (\code{default = FALSE})?
 #' @param url_only boolean, only return the generated URLs (\code{default = FALSE})?
 #'

--- a/man/connection.Rd
+++ b/man/connection.Rd
@@ -26,7 +26,7 @@ connection(
 
 \item{results}{numeric, maximum number of suggested public transport routes (Valid range: 1 and 6).}
 
-\item{transfers}{numeric, maximum number of transfers allowed per route (Valid range: -1 and 6, \code{default = -1}).}
+\item{transfers}{numeric, maximum number of transfers allowed per route (Valid range: -1 and 6, whereby the \code{default = -1} allows for unlimited transfers).}
 
 \item{summary}{boolean, return a summary of the public transport connections instead of the sections of the routes (\code{default = FALSE})?}
 


### PR DESCRIPTION
I was a bit puzzled by the default `-1` for the `transfers` parameter as it wasn't mentioned in the [HERE API description](https://developer.here.com/documentation/public-transit/api-reference-swagger.html).
Thus I've added an explanation.

Thanks for the great package, keep up the good work!
