### PR TITLE
Release/v0.6.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ URL: https://munterfinger.github.io/hereR/, https://github.com/munterfinger/here
 BugReports: https://github.com/munterfinger/hereR/issues/
 Description: Interface to the 'HERE' REST APIs <https://developer.here.com/develop/rest-apis>:
   (1) geocode and autosuggest addresses or reverse geocode POIs using the 'Geocoder' API;
-  (2) route directions, travel distance or time matrices and isolines using the 'Routing' API;
+  (2) route directions, travel distance or time matrices and isolines using the 'Routing', 'Matrix Routing' and 'Isoline Routing' APIs;
   (3) request real-time traffic flow and incident information from the 'Traffic' API;
   (4) find request public transport connections and nearby stations from the 'Public Transit' API;
   (5) request intermodal routes using the 'Intermodal Routing' API;

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hereR
 Type: Package
 Title: 'sf'-Based Interface to the 'HERE' REST APIs
-Version: 0.5.2.9000
+Version: 0.6.0
 Authors@R: c(
     person("Merlin", "Unterfinger", role = c("aut", "cre"), email = "info@munterfinger.ch", comment = c(ORCID = "0000-0003-2020-2366")),
     person("Daniel", "Possenriede", role = "ctb", comment = c(ORCID = "0000-0002-6738-9845")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# version 0.5.2.9000
+# version 0.6.0
 
 * Update `route_matrix()` from **Routing API v7.2** (calculatematrix) to **Matrix Routing API v8** (see [#87](https://github.com/munterfinger/hereR/issues/87)).
 * Update `isoline()` from **Routing API v7.2** (calculateisoline) to **Isoline Routing API v8** (see [#87](https://github.com/munterfinger/hereR/issues/87)).

--- a/man/hereR-package.Rd
+++ b/man/hereR-package.Rd
@@ -8,7 +8,7 @@
 \description{
 Interface to the 'HERE' REST APIs <https://developer.here.com/develop/rest-apis>:
   (1) geocode and autosuggest addresses or reverse geocode POIs using the 'Geocoder' API;
-  (2) route directions, travel distance or time matrices and isolines using the 'Routing' API;
+  (2) route directions, travel distance or time matrices and isolines using the 'Routing', 'Matrix Routing' and 'Isoline Routing' APIs;
   (3) request real-time traffic flow and incident information from the 'Traffic' API;
   (4) find request public transport connections and nearby stations from the 'Public Transit' API;
   (5) request intermodal routes using the 'Intermodal Routing' API;


### PR DESCRIPTION
* Update `route_matrix()` from **Routing API v7.2** (calculatematrix) to **Matrix Routing API v8** (see [#87](https://github.com/munterfinger/hereR/issues/87)).
* Update `isoline()` from **Routing API v7.2** (calculateisoline) to **Isoline Routing API v8** (see [#87](https://github.com/munterfinger/hereR/issues/87)).
* Update `route()` from  **Routing API v7.2** (calculateroute) to **Routing API v8**, which brings the elevation to the route geometries (closes [#87](https://github.com/munterfinger/hereR/issues/87)). **Note:** Currently arrival time is not yet supported.
* Return ISO state and country code in `geocode()` with the updated API v7.2 as it did with the previous API v6 (closes [#98](https://github.com/munterfinger/hereR/issues/98)).
* Deprecate parameters `mode` and `type` in `route()`, `route_matrix()` and `isoline()`, use `transport_mode` and `routing_mode` instead.
* Fix parsing of timezones in `connection()` and `intermodal_route()` (closes [#94](https://github.com/munterfinger/hereR/issues/94)).
* Fix not conditional use of suggested packages in vignettes (closes [#101](https://github.com/munterfinger/hereR/issues/101)).
* Fix issue with delimiter for POST requests by changing it from a space `" "` to a space pipe combination `" | "` (closes [#102](https://github.com/munterfinger/hereR/issues/102)).
* Added contribution guidelines, code of conduct and issue templates.